### PR TITLE
Rescue StandardErrors in the worker

### DIFF
--- a/lib/worker.rb
+++ b/lib/worker.rb
@@ -9,35 +9,36 @@ class Worker
     @task ||= Rake::Task[@task_name_string]
   end
 
-  def run_once
-    log(:debug) { 'Reenabling task...' }
-    task.reenable
-
-    log(:debug) { 'Invoking task...' }
-    task.invoke
-  rescue Exception => ex
-    log(:fatal) { "#{ex.class.name}: #{ex.message}\n#{ex.backtrace.join("\n")}" }
-
-    Raven.capture_exception(ex) unless EXCLUDED_EXCEPTIONS.include? ex.class
-
-    raise ex
-  end
-
   def run(run_every = 1.second)
     start_time = Time.current.freeze
     log(:info) { "Started at #{start_time}" }
 
-    1.upto(Float::INFINITY).each do |iteration|
-      run_once
-
-      wake_up_at = start_time + iteration * run_every
-      sleep_interval = wake_up_at - Time.current
-      if sleep_interval > 0
-        log(:debug) { "#{sleep_interval} second(s) ahead of schedule - sleeping..." }
-        sleep sleep_interval
-      else
-        log(:debug) { "#{-sleep_interval} second(s) behind schedule - skipping sleep" }
+    (0..Float::INFINITY).each do |iteration|
+      if iteration > 0
+        sleep_interval = start_time + iteration * run_every - Time.current
+        if sleep_interval > 0
+          log(:debug) { "#{sleep_interval} second(s) ahead of schedule - sleeping..." }
+          sleep sleep_interval
+        else
+          log(:debug) { "#{-sleep_interval} second(s) behind schedule - skipping sleep" }
+        end
       end
+
+      log(:debug) { 'Reenabling task...' }
+      task.reenable
+
+      log(:debug) { 'Invoking task...' }
+      task.invoke
+    rescue Exception => ex
+      unless EXCLUDED_EXCEPTIONS.include? ex.class
+        log(:fatal) { "#{ex.class.name}: #{ex.message}\n#{ex.backtrace.join("\n")}" }
+
+        Raven.capture_exception(ex)
+      end
+
+      # We ignore any StandardErrors and attempt to continue with the next iteration
+      # Non-StandardErrors (such as SystemExit) are allowed to bubble up and terminate the worker
+      raise(ex) unless ex.is_a? StandardError
     end
   end
 

--- a/spec/lib/worker_spec.rb
+++ b/spec/lib/worker_spec.rb
@@ -5,13 +5,6 @@ RSpec.describe Worker, type: :lib do
 
   before  { TestTaskCounter.reset }
 
-  context '#run_once' do
-    it 'runs the given task once' do
-      expect{ subject.run_once }.not_to raise_error
-      expect(TestTaskCounter.count).to eq 1
-    end
-  end
-
   context '#run' do
     context 'when the worker is ahead of schedule' do
       let(:run_every) { 10.seconds }

--- a/spec/support/tasks/test.rb
+++ b/spec/support/tasks/test.rb
@@ -1,5 +1,8 @@
 require 'rake'
 
+class RescuedError < StandardError
+end
+
 class TestTaskComplete < Exception
 end
 
@@ -19,6 +22,9 @@ module TestTaskCounter
 
     # Raises TestTaskComplete, aborting the Worker, after the given number of runs
     raise TestTaskComplete if count >= MAX_COUNT
+
+    # Otherwise, raises an error that is rescued and ignored
+    raise RescuedError
   end
 end
 


### PR DESCRIPTION
So biglearn-local-query does not crash when biglearn-scheduler is offline.